### PR TITLE
Correcting the zero size file bug that is still annoying me.

### DIFF
--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -136,7 +136,7 @@ def parse_alignments(alignment, results, normalise, number_samples, sample_index
     temp_results = defaultdict()
 
     # test for an empty file
-    if os.stat(alignment).st_size == 0:
+    if not os.path.exists(alignment) or os.stat(alignment).st_size == 0:
         return defaultdict(int)
 
     with open(alignment) as alignment_file:


### PR DESCRIPTION
Steps to test and recreate: 1. Make a small fastq file in a directory
(e.g. with one read that you make up). 2. Run superfocus. This will not
get any hits and thus not have an output file. 3. SF will crash here.

This should be the complete fix this time!

