### PR TITLE
Fixing list concatenation that was not working

### DIFF
--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -91,7 +91,7 @@ def add_relative_abundance(level_results, normalizer):
     for level in level_results:
         relative_abundance = np.divide(list(level_results[level]), normalizer, where=normalizer!=0)
         relative_abundance *= 100
-        level_results[level] = list(level_results[level]) + relative_abundance
+        level_results[level] = list(level_results[level]) + list(relative_abundance)
 
     return level_results
 


### PR DESCRIPTION
Relative abundance was now a numpy array and so list concatenation did not work to append relative abundance to level_results.

Closes #27 