### PR TITLE
Use environment variable for db

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ To install the aligners, having [`conda`](https://conda.io/docs/installation.htm
 
 ## Database
 
+If you have the superfocus databases downloaded already, you can set the `SUPERFOCUS_DB` environment variable to point
+to that directory. Alternatively, you can provide the `--alternate_directory` flag to point to that location.
+
+### Installing the databases
+
 Some of the steps below could be automatized. However, many users have had problem with the database formatting, and it was requested for the initial steps to be manual.
 
 #### Download and uncompress

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -257,7 +257,12 @@ def main():
     # other metrics
     normalise_output = int(args.normalise_output)
     run_focus = args.focus
-    WORK_DIRECTORY = Path(args.alternate_directory) if args.alternate_directory else Path(__file__).parents[0]
+    if args.alternate_directory:
+        WORK_DIRECTORY = args.alternate_directory
+    elif 'SUPERFOCUS_DB' in os.environ:
+        WORK_DIRECTORY = os.environ['SUPERFOCUS_DB']
+    else:
+        WORK_DIRECTORY =  Path(__file__).parents[0]
 
 
     if args.log:

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -258,9 +258,9 @@ def main():
     normalise_output = int(args.normalise_output)
     run_focus = args.focus
     if args.alternate_directory:
-        WORK_DIRECTORY = args.alternate_directory
+        WORK_DIRECTORY = Path(args.alternate_directory)
     elif 'SUPERFOCUS_DB' in os.environ:
-        WORK_DIRECTORY = os.environ['SUPERFOCUS_DB']
+        WORK_DIRECTORY = Path(os.environ['SUPERFOCUS_DB'])
     else:
         WORK_DIRECTORY =  Path(__file__).parents[0]
 


### PR DESCRIPTION
I added an option to set the database path using the environmental variable `SUPERFOCUS_DB`. 

There are instances when we don't know _a priori_ what the path is and so this allows users to set an environmental variable to define the path.

For example, if `super-focus` is included in a snakemake pipeline installed via conda, the user can install the databases somewhere and set the environment variable to point to the database location.

To use:

`export SUPERFOCUS_DB=/path/to/database/location/`

there is now no need to use the `--alternate-directory` flag.