### PR TITLE
Using diamond with SUPER-FOCUS

### DIFF
--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -82,10 +82,6 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
     database = "{}_clusters".format(database)
     blast_mode = 'blastp' if amino_acid == '1' else 'blastx'
 
-    if not os.path.exists(output_dir):
-        sys.stderr.write(f"ERROR: {output_dir} does not exist, even though created!\n")
-        os.makedirs(output_dir, exist_ok=True)
-
     if aligner == "diamond":
         mode_diamond = "" if fast_mode == "1" else "--sensitive"
         database_diamond = "{}/db/static/diamond/{}.db".format(WORK_DIRECTORY, database)

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -3,6 +3,7 @@
 
 import os
 import csv
+import sys
 import time
 
 from pathlib import Path
@@ -91,8 +92,11 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
                                                                              mode_diamond))
         # if we are running on a cluster, we may need to pause here!
         # if latency_delay is 0 we don't do anything
+        oname = f"{output_name}.daa"
+        sys.stderr.write(f"Starting LATENCY at {time.time()} : output: {os.stat(oname)}\n")
         time.sleep(latency_delay)
         # dump
+        sys.stderr.write(f"Ending LATENCY at {time.time()} : output: {os.stat(oname)}\n")
         os.system("diamond view -a {}.daa -o {}.m8 -t {} -p {}".format(output_name, output_name, temp_folder, threads))
         # delete binary file
         os.system("rm {}/*.daa".format(output_dir))

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -99,15 +99,18 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             "-f", "6",
             "-t", temp_folder,
             "-p", threads,
-            "-e", evalue
+            "-e", evalue,
         ]
         if fast_mode != "1":
             diamond_blast.append("--sensitive")
         try:
             retcode = subprocess.call(diamond_blast)
-            print("Diamond blast was terminated by signal", -retcode, file=sys.stderr)
+            if retcode != 0:
+                print("Diamond blast was terminated by signal", retcode, file=sys.stderr)
+                sys.exit(retcode)
         except OSError as e:
             print("Diamond blast execution failed:", e, file=sys.stderr)
+            sys.exit()
 
         # note that this is no longer a two step process
         # the daa format is legacy, and diamond supports native

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -54,7 +54,7 @@ def update_results(results, sample_index, data, normalise, number_samples):
     return results
 
 
-def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode, WORK_DIRECTORY, amino_acid):
+def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode, WORK_DIRECTORY, amino_acid, temp_folder):
     """Align FAST(A/Q) file to database.
 
     Args:
@@ -67,6 +67,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         fast_mode (str): Fast or sensitive mode (default = 1).
         WORK_DIRECTORY (str): Path to directory where works happens.
         amino_acid (str): 0 input nucleotides, 1 amino acid.
+        temp_folder: a temporary directory to write to
 
     Returns:
         str: Path to alignment that was written.
@@ -78,11 +79,6 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
     blast_mode = 'blastp' if amino_acid == '1' else 'blastx'
 
     if aligner == "diamond":
-        temp_folder = Path("{}/db/tmp/".format(WORK_DIRECTORY))
-
-        if not temp_folder.exists():
-            temp_folder.mkdir(parents=True, mode=511)
-
         mode_diamond = "" if fast_mode == "1" else "--sensitive"
         database_diamond = "{}/db/static/diamond/{}.db".format(WORK_DIRECTORY, database)
 
@@ -91,7 +87,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
                                                                              query, output_name, threads, evalue,
                                                                              mode_diamond))
         # dump
-        os.system("diamond view -a {}.daa -o {}.m8".format(output_name, output_name))
+        os.system("diamond view -a {}.daa -o {}.m8 -t {} -p {}".format(output_name, output_name, temp_folder, threads))
         # delete binary file
         os.system("rm {}/*.daa".format(output_dir))
         # add aligner extension to output

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -3,6 +3,7 @@
 
 import os
 import csv
+import time
 
 from pathlib import Path
 from collections import defaultdict
@@ -54,7 +55,8 @@ def update_results(results, sample_index, data, normalise, number_samples):
     return results
 
 
-def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode, WORK_DIRECTORY, amino_acid, temp_folder):
+def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode, WORK_DIRECTORY, amino_acid,
+                temp_folder, latency_delay=0):
     """Align FAST(A/Q) file to database.
 
     Args:
@@ -68,6 +70,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         WORK_DIRECTORY (str): Path to directory where works happens.
         amino_acid (str): 0 input nucleotides, 1 amino acid.
         temp_folder: a temporary directory to write to
+        latency_delay: a time delay we will pause between writing and reading the files. This allows a cluster (or NFS mount) to catch up!
 
     Returns:
         str: Path to alignment that was written.
@@ -86,6 +89,9 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         os.system("diamond {} -t {} -d {} -q {} -a {} -p {} -e {} {}".format(blast_mode, temp_folder, database_diamond,
                                                                              query, output_name, threads, evalue,
                                                                              mode_diamond))
+        # if we are running on a cluster, we may need to pause here!
+        # if latency_delay is 0 we don't do anything
+        time.sleep(latency_delay)
         # dump
         os.system("diamond view -a {}.daa -o {}.m8 -t {} -p {}".format(output_name, output_name, temp_folder, threads))
         # delete binary file

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -114,7 +114,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         # dump
         #os.system("diamond view -a {}.daa -o {}.m8 -t {} -p {}".format(output_name, output_name, temp_folder, threads))
         diamond_view = [
-            "diamond view",
+            "diamond", "view",
             "-a", f"{output_name}.daa",
             "-o", f"{output_name}.m8",
             "-t", temp_folder,

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -95,7 +95,8 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             "diamond", blast_mode,
             "-d", database_diamond,
             "-q", query,
-            "-a", output_name,
+            "-a", f"{output_name}.m8",
+            "-f", "6",
             "-t", temp_folder,
             "-p", threads,
             "-e", evalue
@@ -108,27 +109,12 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         except OSError as e:
             print("Diamond blast execution failed:", e, file=sys.stderr)
 
-        # if we are running on a cluster, we may need to pause here!
-        # if latency_delay is 0 we don't do anything
-        time.sleep(latency_delay)
+        # note that this is no longer a two step process
+        # the daa format is legacy, and diamond supports native
+        # tab separated output
         # dump
         #os.system("diamond view -a {}.daa -o {}.m8 -t {} -p {}".format(output_name, output_name, temp_folder, threads))
-        diamond_view = [
-            "diamond", "view",
-            "-a", f"{output_name}.daa",
-            "-o", f"{output_name}.m8",
-            "-t", temp_folder,
-            "-p", threads
-        ]
-        try:
-            retcode = subprocess.call(diamond_view)
-            print("Diamond blast was terminated by signal", -retcode, file=sys.stderr)
-        except OSError as e:
-            print("Diamond blast execution failed:", e, file=sys.stderr)
 
-
-        # delete binary file
-        os.system("rm {}/*.daa".format(output_dir))
         # add aligner extension to output
         output_name = "{}.m8".format(output_name)
 

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -95,7 +95,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             "diamond", blast_mode,
             "-d", database_diamond,
             "-q", query,
-            "-a", f"{output_name}.m8",
+            "-o", f"{output_name}.m8",
             "-f", "6",
             "-t", temp_folder,
             "-p", threads,

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -82,6 +82,10 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
     database = "{}_clusters".format(database)
     blast_mode = 'blastp' if amino_acid == '1' else 'blastx'
 
+    if not os.path.exists(output_dir):
+        sys.stderr.write(f"ERROR: {output_dir} does not exist, even though created!\n")
+        os.makedirs(output_dir, exist_ok=True)
+
     if aligner == "diamond":
         mode_diamond = "" if fast_mode == "1" else "--sensitive"
         database_diamond = "{}/db/static/diamond/{}.db".format(WORK_DIRECTORY, database)

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -96,7 +96,6 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             "-d", database_diamond,
             "-q", query,
             "-a", output_name,
-            "-o", f"{output_name}.m8",
             "-t", temp_folder,
             "-p", threads,
             "-e", evalue

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -355,7 +355,7 @@ def main():
             logger.info("1.{}) Working on: {}".format(counter + 1, temp_query))
             logger.info("   Aligning sequences in {} to {} using {}".format(temp_query, database, aligner))
             alignment_name = align_reads(Path(queries_folder, temp_query), output_directory, aligner, database, evalue,
-                                         threads, fast_mode, WORK_DIRECTORY, amino_acid)
+                                         threads, fast_mode, WORK_DIRECTORY, amino_acid, tmpdir)
             logger.info("   Parsing Alignments")
             sample_position = query_files.index(temp_query)
             results, binning_reads = parse_alignments(alignment_name, results, normalise_output, len(query_files),

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -234,6 +234,8 @@ def parse_args():
     parser.add_argument("-m", "--focus", help="runs FOCUS; 1 does run; 0 does not run: default 0.", default="0")
     parser.add_argument("-b", "--alternate_directory", help="Alternate directory for your databases.", default="")
     parser.add_argument('-d', '--delete_alignments', help='Delete alignments', action='store_true', required=False)
+    parser.add_argument('-w', '--latency_wait', help='Add a delay (in seconds) between writing the file and reading it',
+                        type=int, default=0)
     parser.add_argument('-l', '--log', help='Path to log file (Default: STDOUT).', required=False)
 
     return parser.parse_args()
@@ -360,8 +362,13 @@ def main():
         for counter, temp_query in enumerate(query_files):
             logger.info("1.{}) Working on: {}".format(counter + 1, temp_query))
             logger.info("   Aligning sequences in {} to {} using {}".format(temp_query, database, aligner))
-            alignment_name = align_reads(Path(queries_folder, temp_query), output_directory, aligner, database, evalue,
-                                         threads, fast_mode, WORK_DIRECTORY, amino_acid, tmpdir)
+            alignment_name = align_reads(Path(queries_folder, temp_query),
+                                         output_dir=output_directory, aligner=aligner,
+                                         database=database, evalue=evalue,
+                                         threads=threads, fast_mode=fast_mode,
+                                         WORK_DIRECTORY=WORK_DIRECTORY,
+                                         amino_acid=amino_acid, temp_folder=tmpdir,
+                                         latency_delay=args.latency_wait)
             logger.info("   Parsing Alignments")
             sample_position = query_files.index(temp_query)
             results, binning_reads = parse_alignments(alignment_name, results, normalise_output, len(query_files),

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -288,8 +288,14 @@ def main():
     tmp = "/tmp"
     if args.temp_directory:
         tmp = args.temp_directory
+        if not os.path.exists(tmp):
+            logger.info(f"Creating temporary path: {tmp}")
+            os.makedirs(tmp, exist_ok=True)
     elif 'TMPDIR' in os.environ:
         tmp = os.environ['TMPDIR']
+        if not os.path.exists(tmp):
+            logger.info(f"Creating temporary path: {tmp}")
+            os.makedirs(tmp, exist_ok=True)
     else:
         sys.stderr.write(f"WARNING: Using {tmp} as the base temporary directory")
     tmpdir = tempfile.mkdtemp(dir=tmp)

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -6,6 +6,7 @@ import csv
 import itertools
 import logging
 import os
+import shutil
 import sys
 import tempfile
 
@@ -390,7 +391,7 @@ def main():
         write_results(temp_results, temp_header, output_file, queries_folder, database, aligner)
 
     # clean up our mess
-    tmpdir.cleanup()
+    shutil.rmtree(tmpdir)
 
     logger.info('Done')
 


### PR DESCRIPTION
There is an issue running multiple instances of `SUPER-FOCUS` when they are instantiated e.g. from `snakemake`. This PR does two things:

1. Create a temp directory for the intermediate files to be written to
2. Convert `os.system` calls to `subprocess` calls which are more robust and allow you to check the return code.

This PR will improve the overall stability of using `diamond` with `SUPER-FOCUS`

However, this does not completely resolve the issue with running `SUPER-FOCUS` using `diamond` on a cluster. The `diamond` documentation, alas, says not to do this (see _How to run the program on multiple input files?_ on the [diamond FAQ](https://github.com/bbuchfink/diamond/wiki/4.-Support-&-FAQ)