### PR TITLE
Add --db-dir argument to downloadDB script

### DIFF
--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -54,10 +54,18 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
     for dbname in cluster_identities:
         fasta_file = '{}_clusters.fasta'.format(dbname)
         cluster_dir = Path(target_files) / '{}_clusters'.format(dbname)
+        if not cluster_dir.exists():
+            LOGGER.error('Cluster directory "{}" does not exist'.format(cluster_dir))
+            LOGGER.error('Did you specify the input directory correctly?')
+            sys.exit(1)
+
         LOGGER.info('Concatenating {}/*.faa > {}'.format(cluster_dir, fasta_file))
-        os.system(
+        cat = os.system(
             'cat {}/*.faa > {}'.format(cluster_dir, fasta_file)
         )
+        if cat != 0:
+            LOGGER.error('Could not concatenate clusters at level {}'.format(dbname))
+            sys.exit(1)
         
         LOGGER.info('Formatting database(s) ...')
         return_codes = []

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -115,14 +115,13 @@ def parse_args():
             epilog="superfocus_downloadDB -a diamond,rapsearch,blast -i clusters/")
 
     parser.add_argument("-a", "--aligner", required=True,
-            help="Aligner name separed by ',' if more than one")
+            help="Aligner name separed by ',' if more than one.")
     parser.add_argument("-c", "--clusters", default="90",
-            help="DB types separed by ',' if more than one (e.g 90,95,98,100). Default: 90")
+            help="DB types separed by ',' if more than one (e.g 90,95,98,100). Default: 90.")
     parser.add_argument("-i", "--input", required=True, 
-            help="Target input files to be formatted into the database")
+            help="Target input files to be formatted into the database.")
     parser.add_argument("-d", "--db-dir", 
-            help="Alternate database directory to store DB files in. "
-            "Default: lib/python3.10/site-packages/superfocus_app/")
+            help="Alternate database directory to store DB files in.")
     parser.add_argument('-v', '--version', 
             action='version', 
             version='superfocus_downloadDB version {}'.format(version))

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -41,7 +41,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
         db_dir (str): Optional path to user-specified working directory to build databases in.
 
     """
-    if db_dir and Path(db_dir).exists() and Path(db_dir).is_dir():
+    if db_dir:
         workdir = Path(db_dir).resolve()
     else:
         workdir = Path(__file__).parents[0]
@@ -141,6 +141,11 @@ def main():
     aligner_db_creators = {os.path.basename(x) for x in check_aligners() if x != 'None'}
     if not aligner_db_creators:
         LOGGER.critical('None of the required aligners are installed {}'.format(list(valid_aligners)))
+        sys.exit(1)
+
+    db_dir_exists = Path(args.db_dir).exists() and Path(args.db_dir).is_dir()
+    if args.db_dir and not db_dir_exists:
+        LOGGER.critical('Provided --db-dir "{}" does not exist'.format(args.db_dir))
         sys.exit(1)
 
     # Parse which aligner(s) the user wants to format the database to

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -16,8 +16,6 @@ LOGGER_FORMAT = '[%(asctime)s - %(levelname)s] %(message)s'
 logging.basicConfig(format=LOGGER_FORMAT, level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 
-WORK_DIRECTORY = str(Path(__file__).parents[0] / 'db/static/')
-
 
 def check_aligners():
     """Check if aligners are installed on the system path.
@@ -46,9 +44,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
     if db_dir and Path(db_dir).exists() and Path(db_dir).is_dir():
         workdir = str(Path(db_dir).resolve())
     else:
-        workdir = WORK_DIRECTORY
-    LOGGER.info('Using work directory: {}'.format(workdir))
-
+        workdir = str(Path(__file__).parents[0] / 'db/static/')
 
     LOGGER.info('Preparing database(s) in workdir: {}'.format(workdir))
     for dbname in cluster_identities:

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -43,11 +43,14 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
         db_dir (str): Optional path to user-specified working directory to build databases in.
 
     """
-    if Path(db_dir).exists() and Path(db_dir).is_dir():
-        WORK_DIRECTORY = str(Path(db_dir).resolve())
-        LOGGER.info('Using work directory: {}'.format(WORK_DIRECTORY))
+    if db_dir and Path(db_dir).exists() and Path(db_dir).is_dir():
+        workdir = str(Path(db_dir).resolve())
+    else:
+        workdir = WORK_DIRECTORY
+    LOGGER.info('Using work directory: {}'.format(workdir))
 
-    LOGGER.info('Preparing database(s) in workdir: {}'.format(WORK_DIRECTORY))
+
+    LOGGER.info('Preparing database(s) in workdir: {}'.format(workdir))
     for dbname in cluster_identities:
         fasta_file = '{}_clusters.fasta'.format(dbname)
         cluster_dir = Path(target_files) / '{}_clusters'.format(dbname)
@@ -60,7 +63,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
         return_codes = []
         if 'prerapsearch' in aligners:
             LOGGER.info('RAPSearch2: DB_{}'.format(dbname))
-            outdir = Path('{}/{}'.format(WORK_DIRECTORY, "rapsearch2"))
+            outdir = Path('{}/{}'.format(workdir, "rapsearch2"))
             outdir.mkdir(parents=True, exist_ok=True)
             return_codes.append((
                 "prerapsearch", 
@@ -69,7 +72,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
             )))
         if 'diamond' in aligners:
             LOGGER.info('DIAMOND: DB_{}'.format(dbname))
-            outdir = Path('{}/{}'.format(WORK_DIRECTORY, "diamond"))
+            outdir = Path('{}/{}'.format(workdir, "diamond"))
             outdir.mkdir(parents=True, exist_ok=True)
             return_codes.append((
                 "diamond", 
@@ -78,7 +81,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
             )))
         if 'makeblastdb' in aligners:
             LOGGER.info('BLAST: DB_{}'.format(dbname))
-            outdir = Path('{}/{}'.format(WORK_DIRECTORY, "blast"))
+            outdir = Path('{}/{}'.format(workdir, "blast"))
             outdir.mkdir(parents=True, exist_ok=True)
             return_codes.append((
                 "blast", 

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -171,6 +171,7 @@ def main():
         LOGGER.info('Done :)')
     else:
         LOGGER.critical('No valid aligner. We cannot move on!')
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -42,9 +42,10 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
 
     """
     if db_dir and Path(db_dir).exists() and Path(db_dir).is_dir():
-        workdir = str(Path(db_dir).resolve())
+        workdir = Path(db_dir).resolve()
     else:
-        workdir = str(Path(__file__).parents[0] / 'db/static/')
+        workdir = Path(__file__).parents[0]
+    db_static_dir = workdir / 'db/static/'
 
     LOGGER.info('Preparing database(s) in workdir: {}'.format(workdir))
     for dbname in cluster_identities:
@@ -67,7 +68,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
         return_codes = []
         if 'prerapsearch' in aligners:
             LOGGER.info('RAPSearch2: DB_{}'.format(dbname))
-            outdir = Path('{}/{}'.format(workdir, "rapsearch2"))
+            outdir = Path('{}/{}'.format(db_static_dir, "rapsearch2"))
             outdir.mkdir(parents=True, exist_ok=True)
             return_codes.append((
                 "prerapsearch", 
@@ -76,7 +77,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
             )))
         if 'diamond' in aligners:
             LOGGER.info('DIAMOND: DB_{}'.format(dbname))
-            outdir = Path('{}/{}'.format(workdir, "diamond"))
+            outdir = Path('{}/{}'.format(db_static_dir, "diamond"))
             outdir.mkdir(parents=True, exist_ok=True)
             return_codes.append((
                 "diamond", 
@@ -85,7 +86,7 @@ def format_database(aligners, target_files, cluster_identities, db_dir):
             )))
         if 'makeblastdb' in aligners:
             LOGGER.info('BLAST: DB_{}'.format(dbname))
-            outdir = Path('{}/{}'.format(workdir, "blast"))
+            outdir = Path('{}/{}'.format(db_static_dir, "blast"))
             outdir.mkdir(parents=True, exist_ok=True)
             return_codes.append((
                 "blast", 

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
+"""SUPER-FOCUS: A tool for agile functional analysis of shotgun metagenomic data"""
 
 import argparse
 import os
@@ -85,17 +85,23 @@ def parse_args():
         argparse.Namespace: Parsed arguments.
 
     """
-    parser = argparse.ArgumentParser(description="SUPER-FOCUS: A tool for agile functional analysis of shotgun "
-                                                 "metagenomic data",
-                                     epilog="superfocus_downloadDB -a diamond,rapsearch,blast -i clusters/")
-    # basic parameters
-    parser.add_argument("-a", "--aligner", help="Aligner name separed by ',' if more than one", required=True)
-    parser.add_argument("-c", "--clusters", help="DB types separed by ',' if more than one (e.g 90,95,98,"
-                                                 "100) - default 90",
-                        required=False, default="90")
-    parser.add_argument("-i", "--input", help="Target input files to be formatted into the database", required=True)
-    parser.add_argument('-v', '--version', action='version', version='superfocus_downloadDB version {}'.format(
-        version))
+    parser = argparse.ArgumentParser(
+            description=__doc__, 
+            epilog="superfocus_downloadDB -a diamond,rapsearch,blast -i clusters/")
+
+    parser.add_argument("-a", "--aligner", required=True,
+            help="Aligner name separed by ',' if more than one")
+    parser.add_argument("-c", "--clusters", default="90",
+            help="DB types separed by ',' if more than one (e.g 90,95,98,100). Default: 90")
+    parser.add_argument("-i", "--input", required=True, 
+            help="Target input files to be formatted into the database")
+    parser.add_argument('-v', '--version', 
+            action='version', 
+            version='superfocus_downloadDB version {}'.format(version))
+
+    if len(sys.argv) < 2:
+        parser.print_help()
+        sys.exit(1)
 
     return parser.parse_args()
 


### PR DESCRIPTION
Hi, I took the liberty of making some minor feature additions/improvements to the `superfocus_downloadDB` script. I was having issues running the script since it wants to create the database files inside my conda environment folder (`~/.conda/envs/superfocus/lib/python3.10/site-packages/superfocus_app/...`) which I don't want it to.

This PR makes the following modifications:
* Add `--db-dir` argument so the user can pick their own custom folder for where to build the databases. This should make it easier for users to run super-focus with the `--alternate_directory` flag since they can pick the folder themselves.
* Improve error handling; previously the script printed happy log messages about successfully completing even if the database building step failed.
* Improve error handling; previously the script tried to chug on even if the user supplied an incorrect path to the input directory structure leading to further downstream errors.
* Refactor code to avoid concatenating cluster fasta files for cluster levels not requested by the user; the script now only creates a concatenated fasta file for the cluster level requested by the user when running the script. The file is deleted afterwards. Previously, the script left unused concatenated fasta files behind. 
* Minor overall code cleanup; more readable code by avoiding long lines where not necessary
* Improve log output. It is now more detailed in general

The functionality should be identical to before if the `--db-dir` argument is not used, but with slightly improved feedback to the user.