### PR TITLE
Allow multiple separate fastq queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ Biochemistry/binary_data
 superfocus_app/clusters/
 superfocus_app/db/clusters/
 out/
+
+# virtual environments
+venv/
+virtualenv/

--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ available command line options:
 
     superfocus -q input_folder -dir output_dir
 
+## Query
+
+The query can be one or more fasta or fastq files, or a directory containing those files. We filter for
+files that end `.fasta`, `.fastq`, or `.fna`, so please ensure any file that you want processed has one
+of those file extensions.
+
+You can provide a mixture of input files or directories, and we will filter the files as appropriate.
+
+For example:
+
+```bash
+superfocus -q fastq1.fastq -q fastq2.fastq -q directory/ -dir output
+```
+
+will process the two fastq files `fastq1.fastq` and `fastq2.fastq` as well as any `fasta` or `fastq` files in `directory`
+and put the output in `output`.
+
+We currently do not handle `gzipped` or otherwise compressed input files.
+
 ## Recomendations
 - The FOCUS reduction is not necessary if not wanted (it is off by default: set `-focus 1` to run FOCUS reduction)
 - Run RAPSearch for short sequences, it is less sensitive for long sequences

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.12
-scipy==0.19
+numpy>=1.12
+scipy>=0.19
 

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -32,7 +32,7 @@ def is_wanted_file(queries):
         list: Sorted list with only .fasta/.fastq/.fna files.
 
     """
-    queries = [query for query in queries if query.split(".")[-1].lower() in ["fna", "fasta", "fastq"]]
+    queries = [query for query in queries if query.name.split(".")[-1].lower() in ["fna", "fasta", "fastq"]]
     queries.sort()
 
     return queries


### PR DESCRIPTION
This PR overloads the `--query` option to allow any of

- a single fasta/q file
- multiple fasta/q files
- a directory of fasta/q files

You can now specify multiple fasta/q files independently rather than providing a directory with them.

e.g.

```
superfocus -q file1.fastq -q file2.fastq -q file3.fastq -dir output
```