### PR TITLE
Include mmseqs2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you have Python 3.6, you can install both dependencies with:
 One of the below aligners, which can easily be installed with [`conda`](https://conda.io/docs/):
 - [DIAMOND 0.9.14](http://ab.inf.uni-tuebingen.de/software/diamond)
 - [RAPSearch2 2.24](http://rapsearch2.sourceforge.net)
+- [MMSEQS2](https://github.com/soedinglab/MMseqs2)
 - [BLAST 2.6.0](https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=Download)
 
 To install the aligners, having [`conda`](https://conda.io/docs/installation.html) installed, simply run:  
@@ -56,7 +57,55 @@ to that directory. Alternatively, you can provide the `--alternate_directory` fl
 
 ### Installing the databases
 
-Some of the steps below could be automatized. However, many users have had problem with the database formatting, and it was requested for the initial steps to be manual.
+Some of the steps below could be automatized. However, many users have had problem with the database formatting, and
+it was requested for the initial steps to be manual.
+
+### Downloading prebuilt databases
+
+We have prebuilt several of the databases, so if you have made a `conda` install, choose the right version and 
+you should be able to download the databases
+
+***Diamond***
+
+Please check your `diamond` version with `diamond --version` and then read the [diamond documentation](https://github.com/bbuchfink/diamond/wiki/5.-Advanced-topics#database-format-versions) to know which version to download. You can also find out the database version you have installed with `diamond dbinfo`.
+
+Cluster Size | diamond version 1 databases | diamond version 2 databases | diamond version 3 databases
+--- | --- | --- | ---
+90 |  [90 v1](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v1/90_clusters.db.dmnd.zip)  | [90 v2](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v2/90_clusters.db.dmnd.zip)  | [90 v3](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v3/90_clusters.db.dmnd.zip) 
+95 |  [95 v1](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v1/95_clusters.db.dmnd.zip)  | [95 v2](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v2/95_clusters.db.dmnd.zip)  | [95 v3](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v3/95_clusters.db.dmnd.zip) 
+98 |  [98 v1](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v1/98_clusters.db.dmnd.zip)  | [98 v2](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v2/98_clusters.db.dmnd.zip)  | [98 v3](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v3/98_clusters.db.dmnd.zip) 
+100 |  [100 v1](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v1/100_clusters.db.dmnd.zip)  | [100 v2](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v2/100_clusters.db.dmnd.zip)  | [100 v3](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/diamond_v3/100_clusters.db.dmnd.zip) 
+
+After downloading, you need to copy these to `lib/python3.8/site-packages/superfocus_app/db/static/diamond` in the same location as superfocus:
+
+e.g. for `90_clusters`:
+```bash
+mkdir -p  $(which superfocus | sed -e 's#bin/superfocus$#lib/python3.8/site-packages/superfocus_app/db/static/diamond#') &&
+unzip -d  $(which superfocus | sed -e 's#bin/superfocus$#lib/python3.8/site-packages/superfocus_app/db/static/diamond#') 90_clusters.db.dmnd.zip
+```
+
+***MMSEQS2***
+
+There is only one version of the MMSEQS2 databases and so the installation is easier!
+
+Cluster Size | mseqs2 databases
+--- | ---
+90 |  [mmseqs_90.zip](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/mmseqs2/mmseqs_90.zip)
+95 |  [mmseqs_95.zip](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/mmseqs2/mmseqs_95.zip)
+98 |  [mmseqs_98.zip](https://edwards.sdsu.edu/SUPERFOCUS/downloads/conda/mmseqs2/mmseqs_98.zip)
+
+
+After downloading, you need to copy these to `lib/python3.8/site-packages/superfocus_app/db/static/diamond` in the same location as superfocus:
+
+e.g. for `90_clusters`:
+```bash
+mkdir -p  $(which superfocus | sed -e 's#bin/superfocus$#lib/python3.8/site-packages/superfocus_app/db/static/mmseqs2#') &&
+unzip -d  $(which superfocus | sed -e 's#bin/superfocus$#lib/python3.8/site-packages/superfocus_app/db/static/mmseqs2#') mmseqs_90.zip
+```
+
+### Manual installation
+
+If those databases don't work, you might need to try the manual installation:
 
 #### Download and uncompress
 First download the database with the steps below or using your favorite method to download and uncompress files:
@@ -109,7 +158,7 @@ available command line options:
       -o OUTPUT_PREFIX, --output_prefix OUTPUT_PREFIX
                             Output prefix (Default: output).
       -a ALIGNER, --aligner ALIGNER
-                            aligner choice (rapsearch, diamond, or blast; default
+                            aligner choice (rapsearch, diamond, mmseqs2, or blast; default
                             rapsearch).
       -mi MINIMUM_IDENTITY, --minimum_identity MINIMUM_IDENTITY
                             minimum identity (default 60 perc).
@@ -164,6 +213,7 @@ We currently do not handle `gzipped` or otherwise compressed input files.
 - The FOCUS reduction is not necessary if not wanted (it is off by default: set `-focus 1` to run FOCUS reduction)
 - Run RAPSearch for short sequences, it is less sensitive for long sequences
 - Primarily use DIAMOND for large datasets only. It is slower than blastx for small datasets
+- Run mmseqs2 if you are running multiple jobs in parallel (e.g. on a cluster).
 - BLAST is known for being really slow
 
 ## Output

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -122,7 +122,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         output_name = "{}.m8".format(output_name)
 
     elif aligner == 'mmseqs2':
-        database_mmseqs = f"{WORK_DIRECTORY}/db/static/mmseqs/{database}.db"
+        database_mmseqs = f"{WORK_DIRECTORY}/db/static/mmseqs2/{database}.db"
         output_name = f"{output_name}.m8"
         mmseqs_blast = [
             "mmseqs", "easy-search",

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -121,7 +121,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         # add aligner extension to output
         output_name = "{}.m8".format(output_name)
 
-    elif aligner == 'mmseqs2':
+    elif aligner == 'mmseqs':
         database_mmseqs = f"{WORK_DIRECTORY}/db/static/mmseqs2/{database}.db"
         output_name = f"{output_name}.m8"
         mmseqs_blast = [
@@ -156,6 +156,9 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
 
         os.system('{} -db {} -query {} -out {} -outfmt 6 -evalue {} -max_target_seqs 250 -num_threads {}'.format(
             blast_mode, database_blast, query, output_name, evalue, threads))
+    else:
+        sys.stderr.write(f"FATAL: Aligner {aligner} not known\n")
+        sys.exit(0)
 
     return output_name
 

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -134,7 +134,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             "-e", evalue,
         ]
         if fast_mode == "1":
-            mmseqs_blast += ["-s", 1.0]
+            mmseqs_blast += ["-s", "1.0"]
         try:
             retcode = subprocess.call(mmseqs_blast)
             if retcode != 0:

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -101,7 +101,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             "-p", threads,
             "-e", evalue,
         ]
-        if not fast_mode:
+        if fast_mode != "1":
             diamond_blast.append("--sensitive")
         try:
             retcode = subprocess.call(diamond_blast)
@@ -133,7 +133,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             "--threads", threads,
             "-e", evalue,
         ]
-        if fast_mode:
+        if fast_mode == "1":
             mmseqs_blast += ["-s", 1.0]
         try:
             retcode = subprocess.call(mmseqs_blast)
@@ -144,7 +144,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
             print("mmseqs2 blast execution failed:", e, file=sys.stderr)
             sys.exit()
     elif aligner == "rapsearch":
-        mode_rapsearch = "T" if fast_mode else "F"
+        mode_rapsearch = "T" if fast_mode == "1" else "F"
         database_rapsearch = "{}/db/static/rapsearch2/{}.db".format(WORK_DIRECTORY, database)
 
         os.system('rapsearch -a {} -q {} -d {} -o {} -v 250 -z {} -e {} -b 0 -s f'.format(mode_rapsearch, query,

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -126,6 +126,7 @@ def align_reads(query, output_dir, aligner, database, evalue, threads, fast_mode
         output_name = f"{output_name}.m8"
         mmseqs_blast = [
             "mmseqs", "easy-search",
+            query,
             database_mmseqs,
             output_name,
             temp_folder,

--- a/superfocus_app/do_alignment.py
+++ b/superfocus_app/do_alignment.py
@@ -205,6 +205,9 @@ def parse_alignments(alignment, results, normalise, number_samples, sample_index
             # extract need info from hit
             current_read_name = row[0]
             temp_mi = float(row[2])
+            if aligner == 'mmseqs' and temp_mi <= 1 and temp_mi >=0:
+                # mmseqs2 reports fraction identity not percent identity!
+                temp_mi *= 100
             temp_ml = float(row[3])
             current_evalue = row[10]
 

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -225,8 +225,8 @@ def parse_args():
                         default="DB_90")
     parser.add_argument("-p", "--amino_acid", help="amino acid input; 0 nucleotides; 1 amino acids (default 0).",
                         default="0")
-    parser.add_argument("-f", "--fast", help="runs RAPSearch2, DIAMOND or MMSEQS2 in fast mode (default: false).",
-                        action='store_true')
+    parser.add_argument("-f", "--fast", help="runs RAPSearch2 or DIAMOND on fast mode - 0 (False) / 1 (True) "
+                        "(default: 1).", default="1")
 
     # extra
     parser.add_argument("-n", "--normalise_output", help="normalises each query counts based on number of hits; "

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -213,7 +213,7 @@ def parse_args():
     parser.add_argument("-tmp", "--temp_directory", help="specify an alternate temporary directory to use")
 
     # aligner related
-    parser.add_argument("-a", "--aligner", help="aligner choice (rapsearch, diamond, or blast; default rapsearch).",
+    parser.add_argument("-a", "--aligner", help="aligner choice (rapsearch, diamond, blast, or mmseqs2; default rapsearch).",
                         default="rapsearch")
     parser.add_argument("-mi", "--minimum_identity", help="minimum identity (default 60 perc).", default="60")
     parser.add_argument("-ml", "--minimum_alignment", help="minimum alignment (amino acids) (default: 15).",
@@ -225,8 +225,8 @@ def parse_args():
                         default="DB_90")
     parser.add_argument("-p", "--amino_acid", help="amino acid input; 0 nucleotides; 1 amino acids (default 0).",
                         default="0")
-    parser.add_argument("-f", "--fast", help="runs RAPSearch2 or DIAMOND on fast mode - 0 (False) / 1 (True) "
-                                             "(default: 1).", default="1")
+    parser.add_argument("-f", "--fast", help="runs RAPSearch2, DIAMOND or MMSEQS2 in fast mode (default: false).",
+                        action='store_true')
 
     # extra
     parser.add_argument("-n", "--normalise_output", help="normalises each query counts based on number of hits; "
@@ -326,8 +326,8 @@ def main():
         logger.critical("DATABASE: DB_{} not valid. Choose DB_90/95/98/or 100".format(database))
 
     # check if aligner is valid
-    elif aligner not in ["diamond", "rapsearch", "blast"]:
-        logger.critical("ALIGNER: {} is not a valid aligner. Please chose among (diamond or rapsearch)".
+    elif aligner not in ["diamond", "rapsearch", "blast", "mmseqs2"]:
+        logger.critical("ALIGNER: {} is not a valid aligner. Please choose among (diamond, blast, rapsearch, or mmseqs2)".
                         format(aligner))
 
     # check if aligner exists

--- a/superfocus_app/superfocus.py
+++ b/superfocus_app/superfocus.py
@@ -260,6 +260,10 @@ def main():
     fast_mode = args.fast
     del_alignments = args.delete_alignments
 
+    # rename mmseqs2 to mmseqs. This is the name of the command, but the program is mmseqs!
+    if aligner == 'mmseqs2':
+        aligner = 'mmseqs'
+
     # other metrics
     normalise_output = int(args.normalise_output)
     run_focus = args.focus
@@ -326,7 +330,7 @@ def main():
         logger.critical("DATABASE: DB_{} not valid. Choose DB_90/95/98/or 100".format(database))
 
     # check if aligner is valid
-    elif aligner not in ["diamond", "rapsearch", "blast", "mmseqs2"]:
+    elif aligner not in ["diamond", "rapsearch", "blast", "mmseqs"]:
         logger.critical("ALIGNER: {} is not a valid aligner. Please choose among (diamond, blast, rapsearch, or mmseqs2)".
                         format(aligner))
 

--- a/superfocus_app/superfocus_downloadDB.py
+++ b/superfocus_app/superfocus_downloadDB.py
@@ -125,7 +125,7 @@ def parse_args():
     """
     parser = argparse.ArgumentParser(
             description=__doc__, 
-            epilog="superfocus_downloadDB -a diamond,rapsearch,blast -i clusters/")
+            epilog="superfocus_downloadDB -a diamond,rapsearch,blast,mmseqs -i clusters/")
 
     parser.add_argument("-a", "--aligner", required=True,
             help="Aligner name separed by ',' if more than one.")


### PR DESCRIPTION
[mmseqs2](https://github.com/soedinglab/MMseqs2) is a modern and robust aligner. This PR adds capability to add MMSeqS2 to superfocus, and releases the databases too.

There are multiple problems using `diamond` in a cluster environment (and, for example, with snakemake). [mmseqs2](https://github.com/soedinglab/MMseqs2) should solve many of those problems.

There is one gotcha - the program is called `mmseqs2` but the binary is `mmseqs` so I try to accept either on the cli, and then use `mmseqs2` in the directory names (to be clear) and `mmseqs` as the executable name.