### PR TITLE
Docker image for singularity

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,54 @@
+FROM --platform=linux/amd64 ubuntu:24.04
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+ARG LIBFABRIC_VERSION=1.21.0
+ARG UBUNTU_RELEASE=noble
+
+# Install required packages and dependencies
+RUN   apt -y update \
+      && apt -y install build-essential wget doxygen gnupg gnupg2 curl apt-transport-https software-properties-common  \
+      git vim gfortran libtool python3-venv ninja-build python3-pip \
+      libnuma-dev python3-dev slurm-client \
+      && apt -y remove --purge --auto-remove cmake \
+      && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
+      | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+      && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ ${UBUNTU_RELEASE} main" \
+      && apt -y update
+
+# Build and install libfabric
+RUN (if [ -e /tmp/build ]; then rm -rf /tmp/build; fi;) \
+      && mkdir -p /tmp/build \
+      && cd /tmp/build \
+      && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
+      && tar xf v${LIBFABRIC_VERSION}.tar.gz \
+      && cd libfabric-${LIBFABRIC_VERSION} \
+      && ./autogen.sh \
+      && ./configure \
+      && make -j 16 \
+      && make install
+
+#
+# Install miniforge
+#
+RUN set -eux ; \
+  curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh ; \
+  bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
+  rm -rf ./Miniforge3-*
+
+# create a directory so we can mount the remote /usr/bin e.g. for local slurm commands
+RUN mkdir /usr/remotebin
+ENV PATH /opt/miniforge3/bin:$PATH:/usr/remotebin
+#
+# Install conda environment
+#
+
+RUN pip install "numpy<2.0"
+RUN conda config --set channel_priority strict
+
+RUN mamba install --freeze-installed -n base -y -c conda-forge -c bioconda -c defaults super-focus mmseqs2
+RUN mkdir -p /superfocus /superfocus_db
+
+ENV PATH /opt/miniforge3/bin:$PATH
+RUN conda clean -af -y
+

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -18,7 +18,7 @@ apt remove -y docker.io && rm -rf /var/lib/docker && apt install -y docker.io
 
 ### Remove any existing docker images
 
-````
+```
 docker images
 docker images | awk '{print $3}' | grep -v IM | xargs docker rmi -f {}
 ```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,96 @@
+# Docker alternative
+
+This docker file creates a new ubuntu image and installs super-focus and mmseqs2. Then there is a directory called `/superfocus` where you can mount your data.
+
+This image is particularly good for singularity!
+
+# Building this image
+
+### Cleaning up before you start
+> If you have been using docker recently, you might want to do a complete nuke
+> of the docker directory and start again. This is the easy way
+> and also updates docker!
+
+```
+sudo -H bash
+apt remove -y docker.io && rm -rf /var/lib/docker && apt install -y docker.io
+```
+
+### Remove any existing docker images
+
+````
+docker images
+docker images | awk '{print $3}' | grep -v IM | xargs docker rmi -f {}
+```
+
+### build a new image
+docker build -t superfocus . > build.out 2> build.err
+
+### tag it and upload to docker quay
+```
+docker login -u $USER
+TAG=37c06e3a9f8a     ## ADD THE BUILD MD5SUM here
+docker tag superfocus $USER/superfocus:v1.6.0_${TAG}
+
+docker push $USER/superfocus:v1.6.0_${TAG}
+```
+
+#  Running the image
+
+You can run the image to see what's there
+
+```
+docker run -i -t $USER/superfocus:v1.6.0_${TAG}  /bin/bash
+```
+
+
+
+# Running Superfocus with singularity
+
+We can use this dockerfile and convert it  into a `.sif` image.
+
+The current tag is 5abbef95a6ca
+
+
+# Load the singularity module and create a new image
+
+
+NOTE: There is (currently) an issue with singularity 4.1.0. If it persists, here is how to load a previous image:
+
+```
+module load pawseyenv/2023.08
+module load singularity/3.11.4-slurm
+```
+
+Otherwise, this will make a superfocus `.sif`
+
+```
+export TAG=5abbef95a6ca
+module load singularity/4.1.0-slurm
+mkdir sif tmp
+# remember that singularity needs the full path (not a relative path, like tmp)
+export SINGULARITY_TMPDIR=$PWD/tmp/
+singularity pull --dir sif docker://linsalrob/superfocus:v1.6.0_${TAG}
+```
+
+Now, you need to link the directories so that everything will work.
+
+Assuming you have
+
+```
+/home/edwa0468/Projects/superfocus
+/home/edwa0468/Projects/superfocus/fasta/
+
+
+/home/edwa0468/Projects/superfocus_db/db/
+/home/edwa0468/Projects/superfocus_db/db/database_PKs.txt
+/home/edwa0468/Projects/superfocus_db/db/static/mmseqs2
+```
+
+
+Then this should work in a slurm job
+
+```
+singularity exec --bind $PWD/:/superfocus,/home/edwa0468/Projects/superfocus_db:/superfocus_db sif/superfocus_v1.6.0_5abbef95a6ca.sif \
+        superfocus -q /superfocus/fasta -t 16 -dir /superfocus/superfocus -a mmseqs2 -db DB_95 -b /superfocus_db 
+```


### PR DESCRIPTION
This PR adds an alternative dockerfile that works out the box with mmseqs2 and can be used as a singularity container. Easy to convert to a `.sif` file for using on a cluster.

Also contains a directory `/superfocus` that can be used to read/write input/output files.